### PR TITLE
Missing chmod prevents the container from running properly on Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,5 @@ RUN echo "Etc/UTC" > /etc/timezone
 
 EXPOSE 8080
 
+RUN chmod +x start.sh
 ENTRYPOINT ["./start.sh"]


### PR DESCRIPTION
I have tested the container on Debian and apparently it requires `chmod +x` to start entrypoint script.